### PR TITLE
fix(users): allow to use pysam as different user

### DIFF
--- a/image/bin/install.sh
+++ b/image/bin/install.sh
@@ -32,7 +32,7 @@ apt-get install --yes --no-install-recommends ${NON_ESSENTIAL_BUILD} ${ESSENTIAL
 gatb_minia.sh
 besst.sh
 
-pip install --user --requirement /usr/local/share/python_requirements.txt
+pip install --requirement /usr/local/share/python_requirements.txt
 
 # Clean up dependencies
 apt-get autoremove --purge --yes ${NON_ESSENTIAL_BUILD}


### PR DESCRIPTION
CWL uses uid mapping when running with Docker. As a different user it is not possible to use libraries installed with `--user`.